### PR TITLE
Add install script and config sanity tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,22 @@ Built to run on a single Linux laptop first, then lifted into production hardwar
 ## Quick start (lab on a single Linux host)
 1. Install dependencies:
    ```bash
-   sudo apt update && sudo apt install -y wireguard nftables dnsmasq bridge-utils docker.io docker-compose-plugin
+   sudo bash scripts/install-deps.sh
    ```
-2. Review and fill secrets in `configs/wireguard/SECRETS.md`.
-3. Bring up VLANs/DHCP/VPN/ACLs:
+2. Run basic config sanity tests:
+   ```bash
+   bash tests/config-sanity.sh
+   ```
+3. Review and fill secrets in `configs/wireguard/SECRETS.md`.
+4. Bring up VLANs/DHCP/VPN/ACLs:
    ```bash
    sudo bash scripts/quicklab.sh
    ```
-4. Start monitoring stack:
+5. Start monitoring stack:
    ```bash
    docker compose -f infra/docker/compose.services.yml up -d
    ```
-5. Add a tenant:
+6. Add a tenant:
    ```bash
    sudo bash scripts/mk-tenant.sh A 101
    ```

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install base packages required for the ZuluAlpha observatory lab
+sudo apt update
+sudo apt install -y \
+  wireguard \
+  nftables \
+  dnsmasq \
+  bridge-utils \
+  docker.io \
+  docker-compose-plugin \
+  ansible
+
+echo "[+] Packages installed. Review configs and run tests with: bash tests/config-sanity.sh"

--- a/tests/config-sanity.sh
+++ b/tests/config-sanity.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Basic checks to ensure lab configs enforce security baseline
+
+fail=0
+
+check() {
+  desc=$1
+  shift
+  if "$@"; then
+    echo "[PASS] $desc"
+  else
+    echo "[FAIL] $desc" >&2
+    fail=1
+  fi
+}
+
+check "nftables drops inbound by default" \
+  grep -q 'counter drop' configs/nftables/ruleset.nft
+
+check "nftables blocks east-west between tenant VLANs" \
+  grep -q 'iifname @tenant_vlans oifname @tenant_vlans drop' configs/nftables/ruleset.nft
+
+check "Mgmt and Services VLAN dnsmasq configs exist" \
+  test -f configs/dnsmasq/mgmt.conf -a -f configs/dnsmasq/services.conf
+
+check "WireGuard configs present" \
+  test -f configs/wireguard/wg-mgmt.conf -a -f configs/wireguard/wg-tenantA.conf
+
+if [ $fail -eq 0 ]; then
+  echo "[+] Config sanity checks passed."
+else
+  echo "[!] One or more checks failed." >&2
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary
- provide `install-deps.sh` to install required packages
- add `config-sanity.sh` to verify nftables, dnsmasq, and WireGuard configs
- document install script and tests in README

## Testing
- `bash tests/config-sanity.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b01780710832cae5c25088a459e75